### PR TITLE
fix "Declare app dependencies" - installation error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ dj-database-url==0.3.0
 Django==1.8.1
 django-postgrespool==0.3.0
 gunicorn==19.3.0
-psycopg2==2.6
+psycopg2==2.6.1
 SQLAlchemy==1.0.4
 whitenoise==1.0.6


### PR DESCRIPTION
fix #11
there is no `psycopg2` version `2.6`, but `psycopg2==2.6.1`