### PR TITLE
update django version for support until at least 2020

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dj-database-url==0.4.1
-Django==1.9.7
+Django==1.11
 gunicorn==19.6.0
 psycopg2==2.6.2
 whitenoise==2.0.6


### PR DESCRIPTION
[https://www.djangoproject.com/download/#supported-versions](url)

Django 1.9 has been out of extended life support for exactly 3 months now. 1.11 works well on heroku. 