### PR TITLE
Updated the default DATABASE in settings.py

### DIFF
--- a/gettingstarted/settings.py
+++ b/gettingstarted/settings.py
@@ -78,8 +78,8 @@ WSGI_APPLICATION = 'gettingstarted.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': '', #insert the name of local database,
     }
 }
 


### PR DESCRIPTION
It took me hours to figure out this error.  When following the
tutorials, it was not mentioned that this default configuration
continue to redirect to sqlite3 on local host instead of postgreSQL
even though it worked just fine deployed.  This correction will allow
the localhost connect to postgreSQL database.