### PR TITLE
Added "pipenv shell" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ $ createdb python_getting_started
 $ python manage.py migrate
 $ python manage.py collectstatic
 
+$ pipenv shell
+
 $ heroku local
 ```
 


### PR DESCRIPTION
Couldn't run `heroku local` without running `pipenv shell` first - this created some confusion until I looked at the heroku.com tutorial which does in fact tell you to run `pipenv shell` first. Adding this command to prevent further confusion in the future for other users who may not read the site.