### PR TITLE
bump version

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.0
+python-3.7.3


### PR DESCRIPTION
Bump Python patch version to stay up to date with the latest Python 3.7 version available on the platform.