### PR TITLE
Use `load static` instead of `load staticfiles`

### DIFF
--- a/hello/templates/db.html
+++ b/hello/templates/db.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
   <div class="container">


### PR DESCRIPTION
Django dependency in requirement.txt is not pinned to Django 2, thus installing latest version 3 of the library. With new version already deprecated [1] `load staticfiles` has now been removed and replaced with `load static`.
1: https://docs.djangoproject.com/en/3.0/releases/2.1/#deprecated-features-2-1

<!-- Hi and welcome to the Heroku Python Getting Started repository!

This Django project is meant to be a starting point for other projects.

If you meant to open a PR against a fork instead of upstream, please adjust the base branch:
https://help.github.com/articles/changing-the-base-branch-of-a-pull-request/

Otherwise thank you in advance for your Pull Request - just remember to
include as much information as possible to help the reviewers :-)
-->
