### PR TITLE
fixed 'load staticfiles' error in db.html

### DIFF
--- a/hello/templates/db.html
+++ b/hello/templates/db.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
   <div class="container">


### PR DESCRIPTION
Changed 'load staticfiles' to 'load static' in db.html
{% load staticfiles %} was removed in django 3 and should be replaced by {% load static %}
https://docs.djangoproject.com/en/dev/releases/3.0/#features-removed-in-3-0
The error prevents the view from rendering.