### PR TITLE
Change 'staticfiles' to 'static' with new Django version

### DIFF
--- a/hello/templates/db.html
+++ b/hello/templates/db.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
   <div class="container">


### PR DESCRIPTION
{% load staticfiles %} and {% load admin_static %} were deprecated in Django 2.1, and removed in Django 3.0. [see last bullet here](https://docs.djangoproject.com/en/dev/releases/3.0/#features-removed-in-3-0)

Tried to follow the getting started guide and ran into this issue when going to the '/db' route. Would create a more consistent experience for all subsequent users for this guide in the future!

