### PR TITLE
Update to Python 3.7.8 for security patches

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.6
+python-3.7.8


### PR DESCRIPTION
In `runtime.txt`, `python 3.7.6` was changed to `python 3.7.8`. Version 3.7.8 includes additional security patches over 3.7.6.