### PR TITLE
Fix load static in db.html

### DIFF
--- a/hello/templates/db.html
+++ b/hello/templates/db.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
   <div class="container">


### PR DESCRIPTION
When running the page at /db as explained in the [tutorial](https://devcenter.heroku.com/articles/getting-started-with-python?singlepage=true#provision-a-database), it errors out indicating that **staticfiles** is not a registered tag library. Changing it to **static** instead of **staticfiles** fixes the issue and makes it match the behavior of index.html