### PR TITLE
Bump Python 3.7.8 to Python 3.7.9

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.8
+python-3.7.9


### PR DESCRIPTION
Bumped Python version from `3.7.8` to `3.7.9`; Python 3.7.9 has several security patches over Python 3.7.8, including:

 - CVE-2020-15801: Fixes `python3x._pth` being ignored on Windows
 - CVE-2020-15523: Ensure `python3.dll` is loaded from correct locations when Python is embedded
 - CVE-2020-14422: The `__hash__()` methods of `ipaddress.IPv4Interface` and `ipaddress.IPv6Interface` incorrectly generated constant hash values of 32 and 128 respectively. This resulted in always causing hash collisions.
 - bpo-39603: Prevent http header injection by rejecting control characters in `http.client.putrequest(…)`.