### PR TITLE
update 'load staticfiles' to 'load static'  to fix error 

### DIFF
--- a/hello/templates/db.html
+++ b/hello/templates/db.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
   <div class="container">


### PR DESCRIPTION
…es' is not a registered tag library. "

Page load fails for db.html
https://stackoverflow.com/questions/55929472/django-templatesyntaxerror-staticfiles-is-not-a-registered-tag-library

<!-- Hi and welcome to the Heroku Python Getting Started repository!

This Django project is meant to be a starting point for other projects.

If you meant to open a PR against a fork instead of upstream, please adjust the base branch:
https://help.github.com/articles/changing-the-base-branch-of-a-pull-request/

Otherwise thank you in advance for your Pull Request - just remember to
include as much information as possible to help the reviewers :-)
-->
