### PR TITLE
Remove redundant `--log-file` gunicorn flag

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn gettingstarted.wsgi --log-file -
+web: gunicorn gettingstarted.wsgi


### PR DESCRIPTION
The gunicorn command line option `--log-file -` was renamed to `--error-logfile -` in gunicorn v0.13.0 in 2011:
https://github.com/benoitc/gunicorn/commit/66f7271c5f67bedc576382a4384604298e6180a0

In addition, in gunicorn v19.2 (released 2015-01-30), `--error-logfile` defaults to `-` so the option can be omitted entirely:
http://docs.gunicorn.org/en/latest/settings.html#errorlog
