### PR TITLE
Simplify the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,43 +2,11 @@
 
 A barebones Django app, which can easily be deployed to Heroku.
 
-This application supports the [Getting Started with Python on Heroku](https://devcenter.heroku.com/articles/getting-started-with-python) article - check it out.
+This application supports the [Getting Started with Python on Heroku](https://devcenter.heroku.com/articles/getting-started-with-python) article - check it out for instructions on how to deploy this app to Heroku and also run it locally.
 
-## Running Locally
-
-Make sure you have Python 3.10 [installed locally](https://docs.python-guide.org/starting/installation/). To push to Heroku, you'll need to install the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli), as well as [Postgres](https://devcenter.heroku.com/articles/heroku-postgresql#local-setup).
-
-```sh
-$ git clone https://github.com/heroku/python-getting-started.git
-$ cd python-getting-started
-
-$ python3 -m venv getting-started
-$ pip install -r requirements.txt
-
-$ createdb python_getting_started
-
-$ python manage.py migrate
-$ python manage.py collectstatic
-
-$ heroku local
-```
-
-Your app should now be running on [localhost:5000](http://localhost:5000/).
-
-## Deploying to Heroku
-
-```sh
-$ heroku create
-$ git push heroku main
-
-$ heroku run python manage.py migrate
-$ heroku open
-```
-or
+Alternatively, you can deploy it using this Heroku Button:
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
-
-## Documentation
 
 For more information about using Python on Heroku, see these Dev Center articles:
 


### PR DESCRIPTION
Previously it duplicated parts of the getting started guide, but was missing steps (eg #151), didn't have instructions for all platforms (eg Windows), and was missing all of the setup steps/troubleshooting advice.

Rather than trying to have brief instructions here (which somewhat miss the point of having a tutorial) that are at risk of getting out of sync with the guide, it makes more sense to only link to the guide.
