### PR TITLE
Update `dj-database-url` to 1.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django>=4.0,<5.0
 gunicorn>=20.0,<21.0
-dj-database-url>=0.5,<0.6
+dj-database-url>=1.0,<2.0
 whitenoise>=6.0,<7.0
 psycopg2>=2.0,<3.0


### PR DESCRIPTION
`dj-database-url` v1.0.0 was just released:
https://github.com/jazzband/dj-database-url/releases/tag/v1.0.0

The only breaking change is dropping of Python 2.7 support, which doesn't affect this project.

Changes:
https://github.com/jazzband/dj-database-url/blob/master/CHANGELOG.md#v100-2022-18-06
https://github.com/jazzband/dj-database-url/compare/v0.5.0...v1.0.0