### PR TITLE
Update README for ending of free plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 A barebones Django app, which can easily be deployed to Heroku.
 
+## Deploying to Heroku
+
+Using resources for this example app counts towards your usage. [Scale your dynos to 0](https://devcenter.heroku.com/articles/scaling#scaling-from-the-dashboard) and [delete your database](https://devcenter.heroku.com/articles/heroku-postgresql#removing-the-add-on) as soon as you are done experimenting to control costs.
+
+By default, apps use Eco dynos if you are subscribed to Eco. Otherwise, it defaults to Basic dynos. The Eco dynos plan is shared across all Eco dynos in your account and is recommended if you plan on deploying many small apps to Heroku. Learn more about our low-cost plans [here](https://blog.heroku.com/new-low-cost-plans).
+
+Eligible students can apply for platform credits through our new [Heroku for GitHub Students program](https://blog.heroku.com/github-student-developer-program).
+
 This application supports the [Getting Started with Python on Heroku](https://devcenter.heroku.com/articles/getting-started-with-python) article - check it out for instructions on how to deploy this app to Heroku and also run it locally.
 
 Alternatively, you can deploy it using this Heroku Button:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A barebones Django app, which can easily be deployed to Heroku.
 
 ## Deploying to Heroku
 
-Using resources for this example app counts towards your usage. [Scale your dynos to 0](https://devcenter.heroku.com/articles/scaling#scaling-from-the-dashboard) and [delete your database](https://devcenter.heroku.com/articles/heroku-postgresql#removing-the-add-on) as soon as you are done experimenting to control costs.
+Using resources for this example app counts towards your usage. [Delete your app](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-apps-destroy) and [database](https://devcenter.heroku.com/articles/heroku-postgresql#removing-the-add-on) as soon as you are done experimenting to control costs.
 
 By default, apps use Eco dynos if you are subscribed to Eco. Otherwise, it defaults to Basic dynos. The Eco dynos plan is shared across all Eco dynos in your account and is recommended if you plan on deploying many small apps to Heroku. Learn more about our low-cost plans [here](https://blog.heroku.com/new-low-cost-plans).
 


### PR DESCRIPTION
Once Heroku's free plans end, creating apps for the tutorial will count towards account Eco hours/credits/charges usage, so this needs to be made clear in the README.

This should not be merged until 28th November, when the plan changes take effect.

GUS-W-12008817.