### PR TITLE
Clean up `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
-venv
-*.pyc
-staticfiles
-.env
+# Python files
+__pycache__/
+.venv/
+venv/
+
+# Django files
+staticfiles/
 db.sqlite3
-getting-started/*
+
+# macOS files
+.DS_Store


### PR DESCRIPTION
* Add `.DS_Store` (macOS metadata files)
* Add `.venv/` since it's a commonly used virtual environment directory name (the existing `venv/` name is still ignored too)
* Switch from `*.pyc` to `__pycache__/` (the former is the Python 2 style)
* The redundant `getting-started/*` entry has been removed (I presume this might have been a leftover from the "install local package as egg" days

GUS-W-13312373.