### PR TITLE
Fix the Heroku Button URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This application supports the [Getting Started with Python on Heroku](https://de
 
 Alternatively, you can deploy it using this Heroku Button:
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/heroku/python-getting-started)
 
 For more information about using Python on Heroku, see these Dev Center articles:
 


### PR DESCRIPTION
The previous URL didn't specify an explicit template parameter, which means Dashboard has to rely upon the referrer, which is no longer passed on, meaning the Button had stopped working.