### PR TITLE
Remove `HerokuDiscoverRunner`

### DIFF
--- a/gettingstarted/settings.py
+++ b/gettingstarted/settings.py
@@ -12,7 +12,6 @@ https://docs.djangoproject.com/en/4.0/topics/settings/
 
 import dj_database_url
 import os
-from django.test.runner import DiscoverRunner
 from pathlib import Path
 
 
@@ -105,10 +104,6 @@ if "DATABASE_URL" in os.environ:
         ssl_require=True,
     )
 
-    # Enable test database if found in CI environment.
-    if "CI" in os.environ:
-        DATABASES["default"]["TEST"] = DATABASES["default"]
-
 
 # Password validation
 # https://docs.djangoproject.com/en/4.0/ref/settings/#auth-password-validators
@@ -149,21 +144,6 @@ STATIC_URL = "static/"
 
 # Enable WhiteNoise's GZip compression of static assets.
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
-
-
-# Test Runner Config
-class HerokuDiscoverRunner(DiscoverRunner):
-    """Test Runner for Heroku CI, which provides a database for you.
-    This requires you to set the TEST database (done for you by settings().)"""
-
-    def setup_databases(self, **kwargs):
-        self.keepdb = True
-        return super(HerokuDiscoverRunner, self).setup_databases(**kwargs)
-
-
-# Use HerokuDiscoverRunner on Heroku CI
-if "CI" in os.environ:
-    TEST_RUNNER = "gettingstarted.settings.HerokuDiscoverRunner"
 
 
 # Default primary key field type


### PR DESCRIPTION
The custom test runner class `HerokuDiscoverRunner` (and its associated `TEST` database config options) have been removed, since they are unnecessary for tests to work in CI (Django now configures everything we need itself).