### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
So that it can bump the major version ranges in `requirements.txt`.

See:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates
