### PR TITLE
Use `--debug-mode` for tests instead of running collectstatic

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,8 +3,8 @@
   "description": "A barebones Python app, which can easily be deployed to Heroku.",
   "image": "heroku/python",
   "repository": "https://github.com/heroku/python-getting-started",
-  "keywords": ["python", "django" ],
-  "addons": [ "heroku-postgresql" ],
+  "keywords": ["python", "django"],
+  "addons": ["heroku-postgresql"],
   "env": {
     "SECRET_KEY": {
       "description": "The secret key for the Django application.",
@@ -14,8 +14,7 @@
   "environments": {
     "test": {
       "scripts": {
-        "test-setup": "python manage.py collectstatic --noinput",
-        "test": "python manage.py test"
+        "test": "./manage.py test --debug-mode"
       }
     }
   }


### PR DESCRIPTION
Running the tests in debug mode means WhiteNoise uses its development mode file finder, which means collectstatic doesn't need to have been run first.

In CI either approach is equally valid, however, locally it's very easy to forget to run collectstatic, so we use the `--debug-mode` approach in `app.json` so users know about this trick when reading the codebase.