### PR TITLE
Disable Django admin by default

### DIFF
--- a/gettingstarted/settings.py
+++ b/gettingstarted/settings.py
@@ -44,7 +44,9 @@ else:
 # Application definition
 
 INSTALLED_APPS = [
-    "django.contrib.admin",
+    # Uncomment this and the entry in `urls.py` if you wish to use the Django admin feature:
+    # https://docs.djangoproject.com/en/4.2/ref/contrib/admin/
+    # "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",

--- a/gettingstarted/urls.py
+++ b/gettingstarted/urls.py
@@ -14,7 +14,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
+# from django.contrib import admin
 from django.urls import path
 
 import hello.views
@@ -22,5 +22,7 @@ import hello.views
 urlpatterns = [
     path("", hello.views.index, name="index"),
     path("db/", hello.views.db, name="db"),
-    path("admin/", admin.site.urls),
+    # Uncomment this and the entry in `INSTALLED_APPS` if you wish to use the Django admin feature:
+    # https://docs.djangoproject.com/en/4.2/ref/contrib/admin/
+    # path("admin/", admin.site.urls),
 ]


### PR DESCRIPTION
The Django admin panel feature has been commented out, to improve security, and to reduce the number of static files that have to be processed during collectstatic. (Given that many people won't use the feature, and it requires additional user setup before it can be used anyway.)