### PR TITLE
Improve WhiteNoise configuration

### DIFF
--- a/gettingstarted/settings.py
+++ b/gettingstarted/settings.py
@@ -44,6 +44,8 @@ else:
 # Application definition
 
 INSTALLED_APPS = [
+    # Use WhiteNoise's runserver implementation instead of the Django default, for dev-prod parity.
+    "whitenoise.runserver_nostatic",
     # Uncomment this and the entry in `urls.py` if you wish to use the Django admin feature:
     # https://docs.djangoproject.com/en/4.2/ref/contrib/admin/
     # "django.contrib.admin",
@@ -57,6 +59,10 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    # Django doesn't support serving static assets in a production-ready way, so we use the
+    # excellent WhiteNoise package to do so instead. The WhiteNoise middleware must be listed
+    # after Django's `SecurityMiddleware` so that security redirects are still performed.
+    # See: https://whitenoise.readthedocs.io
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -148,8 +154,17 @@ USE_TZ = True
 STATIC_ROOT = BASE_DIR / "staticfiles"
 STATIC_URL = "static/"
 
-# Enable WhiteNoise's GZip compression of static assets.
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STORAGES = {
+    # Enable WhiteNoise's GZip and Brotli compression of static assets:
+    # https://whitenoise.readthedocs.io/en/latest/django.html#add-compression-and-caching-support
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
+
+# Don't store the original (un-hashed filename) version of static files, to reduce slug size:
+# https://whitenoise.readthedocs.io/en/latest/django.html#WHITENOISE_KEEP_ONLY_HASHED_FILES
+WHITENOISE_KEEP_ONLY_HASHED_FILES = True
 
 
 # Test Runner Config

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django>=4.0,<5.0
 gunicorn>=20.0,<21.0
 dj-database-url>=2.0,<3.0
-whitenoise>=6.0,<7.0
+whitenoise[brotli]>=6.0,<7.0
 psycopg2>=2.0,<3.0


### PR DESCRIPTION
* Switch from the deprecated `STATICFILES_STORAGE` Django config option to `STORAGES`
* Add `whitenoise.runserver_nostatic` to `INSTALLED_APPS` so that WhiteNoise's runserver implementation is used instead of Django's default implementation, for improved dev-prod parity
* Enable `WHITENOISE_KEEP_ONLY_HASHED_FILES`, which means the original (un-hashed filename) copy of static assets are no longer unnecessarily stored in the slug. (This does mean all Django templates must use the `static` processor for asset URLs, but all of the templates in this guide do that already.)
* Use the `brotli` WhiteNoise package extra, so that the Brotli package ends up being installed, so that static assets can also be served using the more efficient Brotli compression (for browsers that support it, which is all modern browsers), and not just GZip.

See:
https://whitenoise.readthedocs.io/en/latest/django.html