### PR TITLE
Use the C implementation of psycopg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ whitenoise[brotli]>=6.0,<7.0
 # underlying Heroku stack image are picked up automatically, thanks to dynamic linking.
 # On other platforms/in development, the precompiled binary package is used instead, to
 # speed up installation and avoid errors from missing libraries/headers.
-#psycopg; sys_platform == "linux"
+#psycopg[c]; sys_platform == "linux"
 #psycopg[binary]; sys_platform != "linux"


### PR DESCRIPTION
The `psycopg` package defaults to a pure Python implementation.

To opt into the faster C implementation, one has to use the `c` extra.

This differs from the `psycopg2` package (which contrary to the what the name suggests, is the older package), where the base package included the C implementation.

See:
https://www.psycopg.org/psycopg3/docs/basic/install.html#local-installation
https://www.psycopg.org/psycopg3/docs/api/pq.html#pq-impl

GUS-W-14292989.
