### PR TITLE
Improve discoverability of `dj-database-url`'s `env` option

### DIFF
--- a/gettingstarted/settings.py
+++ b/gettingstarted/settings.py
@@ -115,10 +115,11 @@ if IS_HEROKU_APP:
     # In production on Heroku the database configuration is derived from the `DATABASE_URL`
     # environment variable by the dj-database-url package. `DATABASE_URL` will be set
     # automatically by Heroku when a database addon is attached to your Heroku app. See:
-    # https://devcenter.heroku.com/articles/provisioning-heroku-postgres
+    # https://devcenter.heroku.com/articles/provisioning-heroku-postgres#application-config-vars
     # https://github.com/jazzband/dj-database-url
     DATABASES = {
         "default": dj_database_url.config(
+            env="DATABASE_URL",
             conn_max_age=600,
             conn_health_checks=True,
             ssl_require=True,


### PR DESCRIPTION
In cases where something other than the `DATABASE_URL` needs to be set, it was previously hard to know how to customise `dj-database-url`'s config, since the upstream docs don't mention the `env` option.

Now our default config passes an explicit value for `env` (which matches the default value for that argument), to improve discoverability.

In addition, the Heroku Postgres docs link has been updated to deep link to the env vars section, which explains when/why DB env vars will be given alternate colour-prefixed names.

Closes #221.