### PR TITLE
Add `0.0.0.0` to non-production `ALLOWED_HOSTS`

### DIFF
--- a/gettingstarted/settings.py
+++ b/gettingstarted/settings.py
@@ -47,13 +47,13 @@ if not IS_HEROKU_APP:
     DEBUG = True
 
 # On Heroku, it's safe to use a wildcard for `ALLOWED_HOSTS``, since the Heroku router performs
-# validation of the Host header in the incoming HTTP request. On other platforms you may need
-# to list the expected hostnames explicitly to prevent HTTP Host header attacks. See:
+# validation of the Host header in the incoming HTTP request. On other platforms you may need to
+# list the expected hostnames explicitly in production to prevent HTTP Host header attacks. See:
 # https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-ALLOWED_HOSTS
 if IS_HEROKU_APP:
     ALLOWED_HOSTS = ["*"]
 else:
-    ALLOWED_HOSTS = []
+    ALLOWED_HOSTS = [".localhost", "127.0.0.1", "[::1]", "0.0.0.0"]
 
 
 # Application definition


### PR DESCRIPTION
The Dev Center guide instructs users running this project locally to visit `http://localhost:5001`, however, some users don't read the guide properly and instead use the URL output by gunicorn to the logs:

```
[2024-05-27 09:52:07 +0000] [1] [INFO] Listening at: http://0.0.0.0:5001 (1)
```

Django's default debug mode `ALLOWED_HOSTS` only includes `localhost` and `127.0.0.1` etc, so as a result using `0.0.0.0` would result in a `DisallowedHost` error:
https://docs.djangoproject.com/en/5.0/ref/settings/#allowed-hosts

According to RFC5735 `0.0.0.0` shouldn't be a routable IP, however, browsers and some other clients choose to treat it like localhost:
https://stackoverflow.com/a/55646032

Adding it to `ALLOWED_HOSTS` is safe, so we might as well do so to improve the UX when users don't follow the guide properly.

See:
https://devcenter.heroku.com/admin/articles/feedback/2161#27486
https://devcenter.heroku.com/admin/articles/feedback/2161#27738

GUS-W-14193867.