### PR TITLE
Configure gunicorn to bind to the IPv6 interface

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: gunicorn gettingstarted.wsgi
+web: gunicorn --config gunicorn.conf.py gettingstarted.wsgi
 
 # Uncomment this `release` process if you are using a database, so that Django's model
 # migrations are run as part of app deployment, using Heroku's Release Phase feature:

--- a/gettingstarted/settings.py
+++ b/gettingstarted/settings.py
@@ -53,7 +53,7 @@ if not IS_HEROKU_APP:
 if IS_HEROKU_APP:
     ALLOWED_HOSTS = ["*"]
 else:
-    ALLOWED_HOSTS = [".localhost", "127.0.0.1", "[::1]", "0.0.0.0"]
+    ALLOWED_HOSTS = [".localhost", "127.0.0.1", "[::1]", "0.0.0.0", "[::]"]
 
 
 # Application definition

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,16 @@
+# Gunicorn configuration file:
+# https://docs.gunicorn.org/en/stable/configure.html
+# https://docs.gunicorn.org/en/stable/settings.html
+# Note: The classic Python buildpack currently sets a few gunicorn settings automatically via
+# the `GUNICORN_CMD_ARGS` env var (which take priority over the settings in this file):
+# https://github.com/heroku/heroku-buildpack-python/blob/main/vendor/python.gunicorn.sh
+
+import os
+
+# The `PORT` env var is set automatically for web dynos and when using `heroku local`:
+# https://devcenter.heroku.com/articles/dyno-startup-behavior#port-binding-of-web-dynos
+# https://devcenter.heroku.com/articles/heroku-local
+_port = os.environ.get("PORT", 5006)
+# Bind to the IPv6 interface instead of the gunicorn default of IPv4, so the app works in IPv6-only
+# environments. IPv4 connections will still work so long as `IPV6_V6ONLY` hasn't been enabled.
+bind = [f"[::]:{_port}"]


### PR DESCRIPTION
By default when the `PORT` env var is set, gunicorn binds to the IPv4 interface `0.0.0.0:$PORT`:
https://docs.gunicorn.org/en/stable/settings.html#bind

Now, we configure it to bind to the IPv6 interface `[::]:$PORT` instead, allowing the app to work in IPv6-only environments.

We don't have it bind to both the IPv4 and IPv6 interfaces, since otherwise on Linux by default gunicorn would fail to boot with:

```
[ERROR] connection to ('::', 5006) failed: [Errno 98] Address already in use
```

...and when binding to the IPv6 interface IPv4 connections will still work (so long as `IPV6_V6ONLY` hasn't been enabled).

If this strategy causes issues, we could always start using the `reuse_port` option, however, that makes the DX worse for the local development use-case (it's then possible to leave a stale gunicorn process running, which will serve requests and give the impression code changes aren't taking effect).

I've added a `gunicorn.conf.py` config file rather than passing CLI args to the `gunicorn` command, since it allows for more flexibility with the configuration (and there are other settings we'll be adding soon). See:
https://docs.gunicorn.org/en/stable/configure.html

GUS-W-17280180.
