### PR TITLE
Clean up the gunicorn `bind` config

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -7,13 +7,15 @@
 
 import os
 
-# The `PORT` env var is set automatically for web dynos and when using `heroku local`:
+# On Heroku, web dynos must bind to the port number specified via the `PORT` env var. This
+# env var is set automatically for web dynos and also when using `heroku local` locally:
 # https://devcenter.heroku.com/articles/dyno-startup-behavior#port-binding-of-web-dynos
 # https://devcenter.heroku.com/articles/heroku-local
-_port = os.environ.get("PORT", 5006)
-# Bind to the IPv6 interface instead of the gunicorn default of IPv4, so the app works in IPv6-only
-# environments. IPv4 connections will still work so long as `IPV6_V6ONLY` hasn't been enabled.
-bind = [f"[::]:{_port}"]
+# Gunicorn will automatically use the `PORT` env var, however, by default it will bind to the
+# port using the IPv4 interface (`0.0.0.0`). We configure the binding manually to make it bind
+# to the IPv6 interface (`::`) instead, so that the app works in IPv6-only environments too.
+# (IPv4 connections will still work so long as `IPV6_V6ONLY` hasn't been enabled.)
+bind = ["[::]:{}".format(os.environ.get("PORT", 5006))]
 
 # The default `sync` worker is more suited to CPU/network-bandwidth bound workloads, so we
 # instead use the thread based worker type for improved support of blocking I/O workloads:


### PR DESCRIPTION
So that it's on one line and easier to include via the rundoc template for the getting started guide.