### PR TITLE
Configure gunicorn access log

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -50,3 +50,11 @@ timeout = 20
 # This should be set to a value less than the 30 second Heroku dyno shutdown timeout:
 # https://devcenter.heroku.com/articles/dyno-shutdown-behavior
 graceful_timeout = 20
+
+# Enable logging of incoming requests to stdout.
+accesslog = "-"
+
+# Adjust which fields are included in the access log, and make it use the Heroku logfmt
+# style. The `X-Request-Id` and `X-Forwarded-For` headers are set by the Heroku Router:
+# https://devcenter.heroku.com/articles/http-routing#heroku-headers
+access_log_format = 'gunicorn method=%(m)s path="%(U)s" status=%(s)s duration=%(M)sms request_id=%({x-request-id}i)s fwd="%({x-forwarded-for}i)s" user_agent="%(a)s"'


### PR DESCRIPTION
* Explicitly enable the access log (since currently it's only enabled when using the classic Python buildpack, and not locally or when using the Python CNB).
* Customise the gunicorn access log format to make it use the Heroku logfmt style, and to improve which fields are included.

Format before:

```
2024-12-08T16:23:33.457957+00:00 app[web.1]: ::ffff:10.1.50.245 - - [08/Dec/2024:16:23:33 +0000] "GET / HTTP/1.1" 200 9585 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:134.0) Gecko/20100101 Firefox/134.0"
```

Format after:

```
2024-12-08T16:32:47.618296+00:00 app[web.1]: gunicorn method=GET path="/" status=200 duration=14ms request_id=e45f9c86-d6d8-4b79-937e-18c0b6bf859e fwd="123.456.789.0" user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:134.0) Gecko/20100101 Firefox/134.0"
```

Ref heroku/buildpacks-python#4.
GUS-W-17316745.