### PR TITLE
Enable automatic gunicorn reloading in development

### DIFF
--- a/.env
+++ b/.env
@@ -3,4 +3,8 @@
 # running on Heroku - to set env vars for those, see:
 # https://devcenter.heroku.com/articles/config-vars
 
+# This is used in gunicorn.conf.py to set appropriate settings for development vs production.
+ENVIRONMENT="development"
+
+# An example env var used in the tutorial.
 TIMES=2

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -58,3 +58,7 @@ accesslog = "-"
 # style. The `X-Request-Id` and `X-Forwarded-For` headers are set by the Heroku Router:
 # https://devcenter.heroku.com/articles/http-routing#heroku-headers
 access_log_format = 'gunicorn method=%(m)s path="%(U)s" status=%(s)s duration=%(M)sms request_id=%({x-request-id}i)s fwd="%({x-forwarded-for}i)s" user_agent="%(a)s"'
+
+if os.environ.get("ENVIRONMENT") == "development":
+    # Automatically restart gunicorn when the app source changes in development.
+    reload = True


### PR DESCRIPTION
This saves having to manually restart gunicorn after making changes to the app in development when using `heroku local`.

See:
https://docs.gunicorn.org/en/stable/settings.html#reload

GUS-W-17614098.