### PR TITLE
Enable gunicorn's `reuse_port` in production

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -62,3 +62,10 @@ access_log_format = 'gunicorn method=%(m)s path="%(U)s" status=%(s)s duration=%(
 if os.environ.get("ENVIRONMENT") == "development":
     # Automatically restart gunicorn when the app source changes in development.
     reload = True
+else:
+    # Use `SO_REUSEPORT` on the listening socket, which allows for more even request
+    # distribution between workers. See: https://lwn.net/Articles/542629/
+    # We don't enable this in development, since it makes it harder to notice when
+    # duplicate gunicorn processes have accidentally been launched (eg in different
+    # terminals), since the "address already in use" error no longer occurs.
+    reuse_port = True


### PR DESCRIPTION
This causes gunicorn to set `SO_REUSEPORT` on the listening socket, which helps ensure better request distribution between gunicorn workers and thus better performance.

We don't enable this in development, since it makes it harder to notice when duplicate gunicorn processes have accidentally been launched (eg in different terminals), since the "address already in use" error no longer occurs.

See:
https://docs.gunicorn.org/en/stable/settings.html#reuse-port
https://github.com/benoitc/gunicorn/pull/2938
https://lwn.net/Articles/542629/

GUS-W-17614363.