### PR TITLE
Set `PYTHONUNBUFFERED=1` locally

### DIFF
--- a/.env
+++ b/.env
@@ -7,5 +7,8 @@
 # configuration for development vs production.
 ENVIRONMENT="development"
 
+# Prevent log buffering when using using `heroku local` with Django management commands.
+PYTHONUNBUFFERED=1
+
 # An example env var used in the tutorial.
 TIMES=2


### PR DESCRIPTION
Since otherwise when Django management commands like `manage.py runserver` are run via `heroku local`, the log buffering causes the server startup logs to not appear immediately.
