### PR TITLE
Exclude unnecessary files from local Pack CLI builds

### DIFF
--- a/project.toml
+++ b/project.toml
@@ -1,0 +1,19 @@
+[_]
+schema-version = "0.2"
+
+[io.buildpacks]
+# Exclude files from local Pack CLI builds, where .gitignore doesn't apply.
+# TODO: Add trailing slash to entries that are directories, once this issue is fixed:
+# https://github.com/buildpacks/pack/issues/2402
+exclude = [
+    "__pycache__",
+    ".git",
+    ".gitignore",
+    ".github",
+    ".venv",
+    ".DS_Store",
+    ".env",
+    "staticfiles",
+    "db.sqlite3",
+    "venv",
+]


### PR DESCRIPTION
Exclude unnecessary files from images when building locally with `pack build`, where `.gitignore` doesn't apply.

See:
- https://buildpacks.io/docs/for-app-developers/how-to/build-inputs/use-project-toml/
- https://buildpacks.io/docs/reference/config/project-descriptor/#iobuildpacks-table-optional
- https://github.com/buildpacks/spec/blob/main/extensions/project-descriptor.md#iobuildpacksinclude-optional-and-iobuildpacksexclude-optional

Note: We have to omit trailing slashes from entries that are directories due to this upstream bug:
https://github.com/buildpacks/pack/issues/2402

GUS-W-18705417.