### PR TITLE
Remove Brotli dependency

### DIFF
--- a/gettingstarted/settings.py
+++ b/gettingstarted/settings.py
@@ -196,7 +196,7 @@ STATIC_ROOT = BASE_DIR / "staticfiles"
 STATIC_URL = "static/"
 
 STORAGES = {
-    # Enable WhiteNoise's GZip and Brotli compression of static assets:
+    # Enable WhiteNoise's GZip (and Brotli, if installed) compression of static assets:
     # https://whitenoise.readthedocs.io/en/latest/django.html#add-compression-and-caching-support
     "staticfiles": {
         "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 django>=5.2,<5.3
 gunicorn>=23,<24
 dj-database-url>=2,<3
-whitenoise[brotli]>=6,<7
+whitenoise>=6,<7
 
 # Uncomment these lines to use a Postgres database. Both are needed, since in production
 # (which uses Linux) we want to install from source, so that security updates from the


### PR DESCRIPTION
Since the Brotli dependency adds ~7-8MB (depending on arch) to the app image (along with having to download/install the wheel during the build), and isn't currently used by the Getting Started guide, since it doesn't have any static assets that are compressible.

```
$ ls -alh /layers/heroku_python/venv/lib/python3.13/site-packages/
...
-rwxr-xr-x  1 heroku heroku 7.2M Jan  1  1980 _brotli.cpython-313-aarch64-linux-gnu.so
```

```
$ ls -al /workspace/staticfiles/ 
total 16
drwxr-xr-x 2 heroku heroku 4096 Jan  1  1980 .
drwxrwxrwx 5 heroku heroku 4096 Jan  1  1980 ..
-rw-r--r-- 1 heroku heroku 2217 Jan  1  1980 lang-logo.019c8743b7cf.png
-rw-r--r-- 1 heroku heroku  100 Jan  1  1980 staticfiles.json
```

See:
https://whitenoise.readthedocs.io/en/latest/django.html#brotli-compression

GUS-W-18705397.