### PR TITLE
Change the Keep-Alive idle timeout to 95 seconds

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -54,7 +54,7 @@ graceful_timeout = 20
 # connections is always initiated by the router and not gunicorn, to prevent a race condition
 # if the router sends a request to the app just as gunicorn is closing the connection:
 # https://devcenter.heroku.com/articles/http-routing#keepalives
-keepalive = 100
+keepalive = 95
 
 # Enable logging of incoming requests to stdout.
 accesslog = "-"


### PR DESCRIPTION
For consistency with the timeout chosen by other languages since #261 landed:
- https://github.com/heroku/heroku-buildpack-php/pull/823
- https://github.com/heroku/ruby-getting-started/pull/190

GUS-W-18319007.