### PR TITLE
Switch Dependabot to `increase-if-necessary` versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    versioning-strategy: increase-if-necessary


### PR DESCRIPTION
To stop the unnecessary version bump PRs like #277.

See:
https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--

GUS-W-22306442.