### PR TITLE
Fix tutorial build/runtime warnings for Classic (Cedar)

### DIFF
--- a/gettingstarted/settings.py
+++ b/gettingstarted/settings.py
@@ -133,7 +133,7 @@ WSGI_APPLICATION = "gettingstarted.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/6.0/ref/settings/#databases
 
-if IS_HEROKU_APP:
+if IS_HEROKU_APP and "DATABASE_URL" in os.environ:
     # In production on Heroku the database configuration is derived from the `DATABASE_URL`
     # environment variable by the dj-database-url package. `DATABASE_URL` will be set
     # automatically by Heroku when a database addon is attached to your Heroku app. See:
@@ -148,8 +148,10 @@ if IS_HEROKU_APP:
         ),
     }
 else:
-    # When running locally in development or in CI, a sqlite database file will be used instead
-    # to simplify initial setup. Longer term it's recommended to use Postgres locally too.
+    # When running locally in development, in CI, or on Heroku before the database addon has
+    # been attached (e.g. during the build's collectstatic step), a sqlite database file will
+    # be used instead to simplify initial setup. Longer term it's recommended to use Postgres
+    # locally too.
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",


### PR DESCRIPTION
The Heroku Getting Started with Python tutorial (Classic/Cedar) shows `WARNING:root:No DATABASE_URL` during `collectstatic` in the build output and again at runtime startup before the database addon is attached — readers may think something is misconfigured.